### PR TITLE
Passport에 문자열로 되어있는 MemberRole를 Enum으로 수정한다

### DIFF
--- a/contract/contract-api/src/main/kotlin/passport/Extensions.kt
+++ b/contract/contract-api/src/main/kotlin/passport/Extensions.kt
@@ -1,0 +1,4 @@
+package passport
+
+val Passport.isAdmin: Boolean
+    get() = MemberRole.ROLE_ADMIN in roles

--- a/contract/contract-api/src/main/kotlin/passport/MemberRole.kt
+++ b/contract/contract-api/src/main/kotlin/passport/MemberRole.kt
@@ -1,0 +1,11 @@
+package passport
+
+enum class MemberRole {
+    ROLE_USER, ROLE_ADMIN;
+
+    companion object {
+        fun Set<String>.toRoleSet() = map { MemberRole.valueOf(it) }.toSet()
+
+        fun Set<MemberRole>.toStringSet() = map { it.name }.toSet()
+    }
+}

--- a/contract/contract-api/src/main/kotlin/passport/Passport.kt
+++ b/contract/contract-api/src/main/kotlin/passport/Passport.kt
@@ -6,6 +6,6 @@ data class Passport(
 
     val memberId: Long,
     val email: String,
-    val roles: Set<String>,
+    val roles: Set<MemberRole>,
     val nickname: String,
 )

--- a/service/auth-service/src/main/kotlin/auth/application/EmailAuthService.kt
+++ b/service/auth-service/src/main/kotlin/auth/application/EmailAuthService.kt
@@ -17,6 +17,8 @@ import extension.getOrThrow
 import member.MemberAddApi
 import member.MemberApi
 import org.springframework.stereotype.Service
+import passport.MemberRole
+import passport.MemberRole.Companion.toRoleSet
 import passport.Passport
 import security.passport.PassportProvider
 import security.password.PasswordEncoder
@@ -164,7 +166,7 @@ class EmailAuthService(
             authProvider = auth.provider.name,
             memberId = member.memberId,
             email = member.email,
-            roles = member.roles,
+            roles = member.roles.toRoleSet(),
             nickname = member.nickname,
         )
         val encodedPassport = passportProvider.encodePassport(passport)

--- a/service/auth-service/src/main/kotlin/auth/support/LocalTokenGenerator.kt
+++ b/service/auth-service/src/main/kotlin/auth/support/LocalTokenGenerator.kt
@@ -9,6 +9,8 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.core.env.Environment
 import org.springframework.core.env.Profiles
 import org.springframework.stereotype.Component
+import passport.MemberRole
+import passport.MemberRole.Companion.toRoleSet
 import passport.Passport
 import security.passport.PassportProvider
 import security.token.AuthPrincipal
@@ -51,7 +53,7 @@ class LocalTokenGenerator(
             authProvider = AuthProvider.INTERNAL.name,
             memberId = memberId,
             email = "dev",
-            roles = roles,
+            roles = roles.toRoleSet(),
             nickname = "dev",
         )
 

--- a/service/member-service/src/main/kotlin/member/application/MemberService.kt
+++ b/service/member-service/src/main/kotlin/member/application/MemberService.kt
@@ -6,8 +6,9 @@ import error.exception.BusinessException
 import member.MemberGetApi
 import member.domain.member.Member
 import member.domain.member.MemberRepository
-import member.domain.member.MemberRole
+import passport.MemberRole
 import org.springframework.stereotype.Service
+import passport.MemberRole.Companion.toStringSet
 import passport.Passport
 
 @Service
@@ -55,7 +56,7 @@ class MemberService(
         MemberGetApi.Response(
             memberId = member.id,
             email = member.email,
-            roles = member.roles.map { it.name }.toSet(),
+            roles = member.roles.toStringSet(),
             nickname = member.nickname,
             profileImage = member.profileImage
         )

--- a/service/member-service/src/main/kotlin/member/domain/member/Member.kt
+++ b/service/member-service/src/main/kotlin/member/domain/member/Member.kt
@@ -4,6 +4,7 @@ import db.base.LongIdEntity
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
+import passport.MemberRole
 
 @Table("member")
 data class Member(

--- a/service/member-service/src/main/kotlin/member/domain/member/MemberRole.kt
+++ b/service/member-service/src/main/kotlin/member/domain/member/MemberRole.kt
@@ -1,5 +1,0 @@
-package member.domain.member
-
-enum class MemberRole {
-    ROLE_USER, ROLE_ADMIN
-}

--- a/service/member-service/src/main/kotlin/member/infra/db/converter/RoleSetToStringConverter.kt
+++ b/service/member-service/src/main/kotlin/member/infra/db/converter/RoleSetToStringConverter.kt
@@ -1,6 +1,6 @@
 package member.infra.db.converter
 
-import member.domain.member.MemberRole
+import passport.MemberRole
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.WritingConverter
 import org.springframework.stereotype.Component

--- a/service/member-service/src/main/kotlin/member/infra/db/converter/StringToRoleSetConverter.kt
+++ b/service/member-service/src/main/kotlin/member/infra/db/converter/StringToRoleSetConverter.kt
@@ -1,6 +1,6 @@
 package member.infra.db.converter
 
-import member.domain.member.MemberRole
+import passport.MemberRole
 import org.springframework.core.convert.converter.Converter
 import org.springframework.data.convert.ReadingConverter
 import org.springframework.stereotype.Component

--- a/service/product-service/src/main/kotlin/product/product/application/ProductService.kt
+++ b/service/product-service/src/main/kotlin/product/product/application/ProductService.kt
@@ -12,6 +12,7 @@ import member.MemberApi
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Service
 import passport.Passport
+import passport.isAdmin
 import product.product.domain.ProductCustomRepository
 import product.product.domain.ProductRepository
 
@@ -59,7 +60,7 @@ class ProductService(
     suspend fun crawl(passport: Passport, targets: List<CvsTarget>): Boolean {
         validateMember(passport)
 
-        if (!passport.roles.any { it == "ROLE_ADMIN" }) {
+        if (!passport.isAdmin) {
             throw BusinessException(ProductErrorCode.P_002)
         }
 


### PR DESCRIPTION
## 📌 개요 (Summary)

Passport.roles 를 Set<String> 에서 Set<MemberRole>로 수정하였습니다.

## ✨ 변경사항 (Changes)

- [ ] 주요 기능 구현
- [ ] API 스펙 변경
- [ ] 버그 수정
- [ ] 테스트 코드 추가/수정
- [X] 리팩토링
- [ ] 기타 : 

## 🧩 관련 이슈 (Related Issues)

Resolve #75 

## 🔍 주요 작업 내역 (What I Did)

- member-service 에 있던 MemberRole을 contract-api 로 이동
- passport.roles를 Set<String> -> Set<MemberRole>로 추가
- Passport.isAdmin 확장함수 추가

## ❗️리뷰 시 유의사항 (Notice for Reviewer)

잘부탁드립니다 ~!
