### PR TITLE
인기 검색어 캐싱 기능을 추가한다.

### DIFF
--- a/service/product-service/src/main/kotlin/product/ProductServiceApplication.kt
+++ b/service/product-service/src/main/kotlin/product/ProductServiceApplication.kt
@@ -2,7 +2,11 @@ package product
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableCaching
+@EnableScheduling
 @SpringBootApplication(
     scanBasePackages = ["product", "security", "db", "docs", "messagebroker"]
 )

--- a/service/product-service/src/main/kotlin/product/product/application/service/ProductSearchHistoryService.kt
+++ b/service/product-service/src/main/kotlin/product/product/application/service/ProductSearchHistoryService.kt
@@ -1,5 +1,7 @@
 package product.product.application.service
 
+import org.springframework.cache.CacheManager
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import product.product.ProductPopularSearchApi
 import product.product.domain.repository.ProductSearchHistoryRepository
@@ -8,110 +10,83 @@ import java.time.LocalDateTime
 
 @Service
 class ProductSearchHistoryService(
-    private val productSearchHistoryRepository: ProductSearchHistoryRepository
+    private val productSearchHistoryRepository: ProductSearchHistoryRepository,
+    private val cacheManager: CacheManager
 ) {
+    private val CACHE_NAME = "popularSearches"
+    private val CACHE_KEY = "top10"
+
     /**
-     * 상품 조회 시 검색어를 저장합니다.
+     * 검색어 저장: 캐시에 영향을 주지 않고 DB에만 기록합니다. (성능 최적화)
      */
     suspend fun saveSearchHistory(productTitle: String) {
         try {
-            productSearchHistoryRepository.save(
-                ProductSearchHistory(
-                    keyword = productTitle
-                )
-            )
+            productSearchHistoryRepository.save(ProductSearchHistory(keyword = productTitle))
         } catch (e: Exception) {
-            // 로깅은 필요시 추가
-            // 검색어 저장 실패가 전체 흐름에 영향을 주지 않도록 예외를 무시
+            // 로깅 및 예외 무시
         }
     }
 
     /**
-     * 인기 검색어를 조회합니다.
-     * 현재 시간의 정시를 기준으로 해당 시간대의 데이터를 조회하며, 이전 정시 구간과 비교하여 순위 변화를 계산합니다.
-     * 
-     * 예시:
-     * - 14시 42분 → 13시~14시 구간 조회, 12시~13시 구간과 비교
-     * - 13시 59분 → 12시~13시 구간 조회, 11시~12시 구간과 비교
-     * - 00시 00분 → 전날 22시~23시 구간 조회, 전날 21시~22시 구간과 비교
-     * - 00시 01분 → 전날 23시~00시 구간 조회, 전날 22시~23시 구간과 비교
+     * 인기 검색어 조회: 캐시된 데이터를 반환하며, 데이터가 없으면 즉시 업데이트 로직을 실행합니다.
      */
     suspend fun findPopularSearchesWithRanking(): List<ProductPopularSearchApi.PopularSearchItem> {
+        val cache = cacheManager.getCache(CACHE_NAME)
+        val cachedData = cache?.get(CACHE_KEY, List::class.java) as? List<ProductPopularSearchApi.PopularSearchItem>
+
+        // 캐시가 비어있으면(Lazy Loading) 즉시 갱신 후 반환
+        return cachedData ?: refreshPopularSearches()
+    }
+
+    suspend fun scheduledRefresh() {
+        refreshPopularSearches()
+    }
+
+    /**
+     * 실제 데이터를 비교하고 캐시를 갱신하는 핵심 비즈니스 로직
+     */
+    private suspend fun refreshPopularSearches(): List<ProductPopularSearchApi.PopularSearchItem> {
         val now = LocalDateTime.now()
-        
-        // 현재 시간의 정시 계산 (분, 초, 나노초를 0으로 설정)
+        // 1. 현재 정시까지의 전체 누적 Top 10 조회
         val currentHourStart = now.withMinute(0).withSecond(0).withNano(0)
-        
-        // 현재 정시 구간: (현재 정시 - 1시간) ~ 현재 정시
-        // 예: 14시 42분 → 13시 00분 ~ 14시 00분
-        val currentPeriodStart = currentHourStart.minusHours(1)
-        val currentPeriodEnd = currentHourStart
-        
-        // 이전 정시 구간: (현재 정시 - 2시간) ~ (현재 정시 - 1시간)
-        // 예: 14시 42분 → 12시 00분 ~ 13시 00분
-        val previousPeriodStart = currentHourStart.minusHours(2)
-        val previousPeriodEnd = currentHourStart.minusHours(1)
-
-        // 현재 시점: 현재 정시 구간의 인기 검색어
         val currentResults = productSearchHistoryRepository.findPopularSearches(
-            currentPeriodStart, 
-            currentPeriodEnd, 
-            10
+            until = currentHourStart,
+            limit = 10
         )
 
-        // 이전 시점: 이전 정시 구간의 인기 검색어
-        val previousResults = productSearchHistoryRepository.findPopularSearches(
-            previousPeriodStart, 
-            previousPeriodEnd, 
-            10
-        )
+        // 2. 이전에 캐싱되어 있던 데이터 가져오기 (비교용)
+        val previousData = cacheManager.getCache(CACHE_NAME)?.get(CACHE_KEY, List::class.java)
+                as? List<ProductPopularSearchApi.PopularSearchItem>
 
-        // 이전 시점의 데이터를 맵으로 변환 (상품명 -> (순위, 검색횟수))
-        val previousMap = previousResults.mapIndexed { index, result ->
-            result.productTitle to (index + 1 to result.searchCount)
-        }.toMap()
+        // 3. 이전 순위 정보를 Map으로 변환 (상품명 -> 순위)
+        val previousRankMap = previousData?.associate { it.productTitle to it.rank } ?: emptyMap()
 
-        // 현재 시점의 데이터를 순위와 함께 변환
-        return currentResults.mapIndexed { index, current ->
+        // 4. 순위 비교 및 결과 생성
+        val finalResults = currentResults.mapIndexed { index, current ->
             val currentRank = index + 1
-            val previousData = previousMap[current.productTitle]
+            val previousRank = previousRankMap[current.productTitle]
 
-            val changeStatus = when {
-                previousData == null -> {
-                    // 이전 시점에 없었던 경우: NEW
-                    ProductPopularSearchApi.ChangeStatus.NEW
-                }
-                current.searchCount > previousData.second -> {
-                    // 검색 횟수 증가: UP
-                    ProductPopularSearchApi.ChangeStatus.UP
-                }
-                current.searchCount < previousData.second -> {
-                    // 검색 횟수 감소: DOWN
-                    ProductPopularSearchApi.ChangeStatus.DOWN
-                }
-                currentRank < previousData.first -> {
-                    // 검색 횟수는 같지만 순위 상승: UP
-                    ProductPopularSearchApi.ChangeStatus.UP
-                }
-                currentRank > previousData.first -> {
-                    // 검색 횟수는 같지만 순위 하락: DOWN
-                    ProductPopularSearchApi.ChangeStatus.DOWN
-                }
-                else -> {
-                    // 순위와 검색 횟수 모두 동일: SAME
-                    ProductPopularSearchApi.ChangeStatus.SAME
-                }
+            val status = when {
+                previousData == null -> ProductPopularSearchApi.ChangeStatus.SAME // 초기 기동 시
+                previousRank == null -> ProductPopularSearchApi.ChangeStatus.NEW // 새로 진입
+                currentRank < previousRank -> ProductPopularSearchApi.ChangeStatus.UP   // 순위 상승 (숫자가 작아짐)
+                currentRank > previousRank -> ProductPopularSearchApi.ChangeStatus.DOWN // 순위 하락
+                else -> ProductPopularSearchApi.ChangeStatus.SAME
             }
 
             ProductPopularSearchApi.PopularSearchItem(
                 rank = currentRank,
                 productTitle = current.productTitle,
                 searchCount = current.searchCount,
-                changeStatus = changeStatus,
-                previousRank = previousData?.first,
-                previousSearchCount = previousData?.second
+                changeStatus = status,
+                previousRank = previousRank,
+                previousSearchCount = null // 누적 데이터라 이전 count 비교의 실익이 적으므로 null 혹은 필요시 추가
             )
         }
+
+        // 5. 캐시 업데이트
+        cacheManager.getCache(CACHE_NAME)?.put(CACHE_KEY, finalResults)
+
+        return finalResults
     }
 }
-

--- a/service/product-service/src/main/kotlin/product/product/config/ProductCrawlingConfig.kt
+++ b/service/product-service/src/main/kotlin/product/product/config/ProductCrawlingConfig.kt
@@ -4,5 +4,4 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @Configuration
-@EnableScheduling
 class ProductCrawlingConfig

--- a/service/product-service/src/main/kotlin/product/product/domain/repository/ProductSearchHistoryRepositoryCustom.kt
+++ b/service/product-service/src/main/kotlin/product/product/domain/repository/ProductSearchHistoryRepositoryCustom.kt
@@ -4,12 +4,6 @@ import java.time.LocalDateTime
 
 interface ProductSearchHistoryRepositoryCustom {
     suspend fun findPopularSearches(
-        since: LocalDateTime,
-        limit: Int
-    ): List<PopularSearchResult>
-
-    suspend fun findPopularSearches(
-        since: LocalDateTime,
         until: LocalDateTime?,
         limit: Int
     ): List<PopularSearchResult>

--- a/service/product-service/src/main/kotlin/product/product/domain/repository/ProductSearchHistoryRepositoryCustomImpl.kt
+++ b/service/product-service/src/main/kotlin/product/product/domain/repository/ProductSearchHistoryRepositoryCustomImpl.kt
@@ -10,44 +10,31 @@ class ProductSearchHistoryRepositoryCustomImpl(
     private val client: DatabaseClient
 ) : ProductSearchHistoryRepositoryCustom {
     override suspend fun findPopularSearches(
-        since: LocalDateTime,
-        limit: Int
-    ): List<ProductSearchHistoryRepositoryCustom.PopularSearchResult> {
-        return findPopularSearches(since, null, limit)
-    }
-
-    override suspend fun findPopularSearches(
-        since: LocalDateTime,
         until: LocalDateTime?,
         limit: Int
     ): List<ProductSearchHistoryRepositoryCustom.PopularSearchResult> {
         val sql = if (until != null) {
             """
-            SELECT keyword, COUNT(*) as search_count
-            FROM product_search_history
-            WHERE created_at >= :since AND created_at < :until
-            GROUP BY keyword
-            ORDER BY search_count DESC, keyword ASC
-            LIMIT :limit
-            """.trimIndent()
+        SELECT keyword, COUNT(*) as search_count
+        FROM product_search_history
+        WHERE created_at < :until
+        GROUP BY keyword
+        ORDER BY search_count DESC, keyword ASC
+        LIMIT :limit
+        """.trimIndent()
         } else {
             """
-            SELECT keyword, COUNT(*) as search_count
-            FROM product_search_history
-            WHERE created_at >= :since
-            GROUP BY keyword
-            ORDER BY search_count DESC, keyword ASC
-            LIMIT :limit
-            """.trimIndent()
+        SELECT keyword, COUNT(*) as search_count
+        FROM product_search_history
+        GROUP BY keyword
+        ORDER BY search_count DESC, keyword ASC
+        LIMIT :limit
+        """.trimIndent()
         }
 
-        var query = client.sql(sql)
-            .bind("since", since)
-            .bind("limit", limit)
-
-        if (until != null) {
-            query = query.bind("until", until)
-        }
+        val query = client.sql(sql).let {
+            if (until != null) it.bind("until", until) else it
+        }.bind("limit", limit)
 
         return query
             .map { row, _ ->
@@ -56,9 +43,7 @@ class ProductSearchHistoryRepositoryCustomImpl(
                     searchCount = (row.get("search_count") as Number).toLong()
                 )
             }
-            .all()
-            .collectList()
-            .awaitSingle()
+            .all().collectList().awaitSingle()
     }
 }
 

--- a/service/product-service/src/main/kotlin/product/product/domain/repository/ProductSearchHistoryRepositoryCustomImpl.kt
+++ b/service/product-service/src/main/kotlin/product/product/domain/repository/ProductSearchHistoryRepositoryCustomImpl.kt
@@ -9,28 +9,31 @@ import java.time.LocalDateTime
 class ProductSearchHistoryRepositoryCustomImpl(
     private val client: DatabaseClient
 ) : ProductSearchHistoryRepositoryCustom {
+
+    /**
+     * 현재 시간의 정시를 기준으로 가장 많이 검색된 데이터를 가져옵니다.
+     * 만약 동일한 랭킹이 있을 경우, 다음 로직에 따릅니다.
+     * 1. 가장 최근에 검색이 된 데이터가 더 높은 순위를 차지합니다.
+     * 2. 1번 마저도 동일한 경우, 이름순으로 정렬합니다.
+     * */
     override suspend fun findPopularSearches(
         until: LocalDateTime?,
         limit: Int
     ): List<ProductSearchHistoryRepositoryCustom.PopularSearchResult> {
-        val sql = if (until != null) {
-            """
-        SELECT keyword, COUNT(*) as search_count
+        val sql = """
+        SELECT 
+            keyword, 
+            COUNT(*) as search_count, 
+            MAX(created_at) as last_searched_at
         FROM product_search_history
-        WHERE created_at < :until
+        ${if (until != null) "WHERE created_at < :until" else ""}
         GROUP BY keyword
-        ORDER BY search_count DESC, keyword ASC
+        ORDER BY 
+            search_count DESC,
+            last_searched_at DESC,
+            keyword ASC
         LIMIT :limit
-        """.trimIndent()
-        } else {
-            """
-        SELECT keyword, COUNT(*) as search_count
-        FROM product_search_history
-        GROUP BY keyword
-        ORDER BY search_count DESC, keyword ASC
-        LIMIT :limit
-        """.trimIndent()
-        }
+    """.trimIndent()
 
         val query = client.sql(sql).let {
             if (until != null) it.bind("until", until) else it

--- a/service/product-service/src/main/kotlin/product/product/presentation/scheduler/ProductPopularSearchScheduler.kt
+++ b/service/product-service/src/main/kotlin/product/product/presentation/scheduler/ProductPopularSearchScheduler.kt
@@ -1,0 +1,24 @@
+package product.product.presentation.scheduler
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import product.product.application.service.ProductSearchHistoryService
+
+@Component
+class ProductPopularSearchScheduler(
+    private val productSearchHistoryService: ProductSearchHistoryService
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 매 정시(00분 00초)마다 캐시를 업데이트하는 배치 로직
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    suspend fun scheduledRefresh() {
+        log.info("[PopularSearch] Refresh start")
+        productSearchHistoryService.scheduledRefresh()
+        log.info("[PopularSearch] Refresh end")
+    }
+}


### PR DESCRIPTION
## 📌 개요 (Summary)

> 인기 검색어 조회 로직 수정 및 성능 개선

서비스에 이용자가 늘어, 하루를 기준으로 매 시간당 검색량이 임계치(10회 이상)를 초과할 경우에만 시간대별 조회를 해야할 것 같습니다. 이거는 승연님에게 우선 문의를 남겨둔 상태입니다!

**[기존 방식 및 문제점]** 

기존에는 API 요청 시마다 최근 1시간과 직전 1시간의 데이터를 실시간으로 비교하여 순위 변동 상태를 계산했습니다. 이로 인해 API 호출 시마다 다수의 DB 접근이 발생하여 부하가 컸으며, 이 데이터의 결과가 10개 미만일 경우, 전체 데이터 중에 가장 많이 검색된 다른 데이터를 추가하는 방식을 사용했습니다. 이는, 조회 범위의 불일치로 인해 상위 10개 데이터의 정합성이 맞지 않는 문제가 있었습니다.

**[개선 사항]**

트래픽 기반 로직 분기: 서비스 초기 단계에서는 전체 기간 데이터를 기반으로 하되, 첫 조회 시 DB 결과를 캐싱하고, 이후 매 시 정각마다 스케줄러를 통해 캐시를 갱신합니다. 실시간 DB 조회 대신, 기존 캐시 데이터와 새로 업데이트된 데이터를 비교하여 순위 및 변동 상태를 계산함으로써 DB 부하를 최소화했습니다.

## ✨ 변경사항 (Changes)

- [x] 주요 기능 구현
- [ ] API 스펙 변경
- [ ] 버그 수정
- [ ] 테스트 코드 추가/수정
- [x] 기타 : 리팩터링

## 🧩 관련 이슈 (Related Issues)

closed #143

## 🔍 주요 작업 내역 (What I Did)

- `ProductPopularSearchScheduler`에서 인기 검색어 캐싱 기능 구현
- `ProductSearchHistoryService`에 캐싱된 데이터 조회 로직 추가
- `ProductServiceApplication`에 `@EnableCaching`, `@EnableScheduling` 어노테이션 추가
- 인기 검색어 조회 시 정렬 로직 수정

## ❗️리뷰 시 유의사항 (Notice for Reviewer)

잘 부탁드립니다~!